### PR TITLE
feat: Add dark mode support and cat image gallery

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -53,6 +53,7 @@ kotlin {
             implementation(compose.runtime)
             implementation(compose.foundation)
             implementation(compose.material3)
+            implementation(compose.materialIconsExtended)
             implementation(compose.ui)
             implementation(compose.components.resources)
             implementation(compose.components.uiToolingPreview)
@@ -66,6 +67,8 @@ kotlin {
             implementation(libs.ktor.serialization.kotlinx.json)
             implementation(libs.ktor.client.logging)
             implementation(libs.kotlinx.serialization.json)
+            implementation(libs.coil.compose)
+            implementation(libs.coil.network.ktor)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/composeApp/src/androidMain/kotlin/org/godslew/gkcatinfosampleapp/MainApplication.kt
+++ b/composeApp/src/androidMain/kotlin/org/godslew/gkcatinfosampleapp/MainApplication.kt
@@ -2,6 +2,7 @@ package org.godslew.gkcatinfosampleapp
 
 import android.app.Application
 import org.godslew.gkcatinfosampleapp.di.appModule
+import org.godslew.gkcatinfosampleapp.di.androidImageLoaderModule
 import org.godslew.gkcatinfosampleapp.di.networkModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
@@ -14,7 +15,7 @@ class MainApplication : Application() {
         startKoin {
             androidLogger()
             androidContext(this@MainApplication)
-            modules(appModule, networkModule)
+            modules(appModule, networkModule, androidImageLoaderModule)
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/org/godslew/gkcatinfosampleapp/di/ImageLoaderModule.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/godslew/gkcatinfosampleapp/di/ImageLoaderModule.android.kt
@@ -1,0 +1,37 @@
+package org.godslew.gkcatinfosampleapp.di
+
+import android.content.Context
+import coil3.ImageLoader
+import coil3.disk.DiskCache
+import coil3.disk.directory
+import coil3.memory.MemoryCache
+import coil3.network.ktor3.KtorNetworkFetcherFactory
+import coil3.request.crossfade
+import coil3.util.DebugLogger
+import io.ktor.client.HttpClient
+import okio.Path.Companion.toOkioPath
+import org.koin.dsl.module
+
+val androidImageLoaderModule = module {
+    single {
+        val context = get<Context>()
+        ImageLoader.Builder(context)
+            .components {
+                add(KtorNetworkFetcherFactory(get<HttpClient>()))
+            }
+            .memoryCache {
+                MemoryCache.Builder()
+                    .maxSizePercent(context, 0.25)
+                    .build()
+            }
+            .diskCache {
+                DiskCache.Builder()
+                    .directory(context.cacheDir.resolve("image_cache").toOkioPath())
+                    .maxSizeBytes(512L * 1024 * 1024) // 512MB
+                    .build()
+            }
+            .logger(DebugLogger())
+            .crossfade(true)
+            .build()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/godslew/gkcatinfosampleapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/godslew/gkcatinfosampleapp/App.kt
@@ -1,68 +1,134 @@
 package org.godslew.gkcatinfosampleapp
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.Image
+import androidx.compose.animation.core.*
 import androidx.compose.foundation.layout.*
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
-import org.jetbrains.compose.resources.painterResource
+import coil3.ImageLoader
+import coil3.compose.AsyncImage
+import coil3.compose.setSingletonImageLoaderFactory
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.godslew.gkcatinfosampleapp.presentation.CatViewModel
+import org.godslew.gkcatinfosampleapp.theme.AppTheme
 import org.koin.compose.viewmodel.koinViewModel
+import org.koin.compose.koinInject
 
-import gkcatinfosampleapp.composeapp.generated.resources.Res
-import gkcatinfosampleapp.composeapp.generated.resources.compose_multiplatform
-
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 @Preview
 fun App() {
-    MaterialTheme {
+    val imageLoader = koinInject<ImageLoader>()
+    setSingletonImageLoaderFactory { context ->
+        imageLoader
+    }
+    
+    AppTheme {
         val viewModel = koinViewModel<CatViewModel>()
         val uiState by viewModel.uiState.collectAsState()
         
-        Column(
-            modifier = Modifier
-                .safeContentPadding()
-                .fillMaxSize()
-                .padding(16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
-        ) {
-            Image(
-                painterResource(Res.drawable.compose_multiplatform),
-                contentDescription = null,
-                modifier = Modifier.size(200.dp)
-            )
-            
-            Spacer(modifier = Modifier.height(32.dp))
-            
-            when {
-                uiState.isLoading -> {
-                    CircularProgressIndicator()
-                    Text("Loading cat information...", modifier = Modifier.padding(top = 8.dp))
-                }
-                uiState.catInfo != null -> {
-                    uiState.catInfo?.let { catInfo ->
-                        Card(
-                            modifier = Modifier.fillMaxWidth(),
-                            elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+        val infiniteTransition = rememberInfiniteTransition(label = "refresh")
+        val rotation by infiniteTransition.animateFloat(
+            initialValue = 0f,
+            targetValue = 360f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(1000, easing = LinearEasing),
+                repeatMode = RepeatMode.Restart
+            ),
+            label = "rotation"
+        )
+        
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text("Cat Gallery") },
+                    actions = {
+                        IconButton(
+                            onClick = { viewModel.refresh() },
+                            enabled = !uiState.isLoading
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Refresh,
+                                contentDescription = "Refresh",
+                                modifier = Modifier.rotate(if (uiState.isLoading) rotation else 0f)
+                            )
+                        }
+                    }
+                )
+            }
+        ) { paddingValues ->
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+            ) {
+                when {
+                    uiState.isLoading -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
                         ) {
                             Column(
-                                modifier = Modifier.padding(16.dp),
-                                horizontalAlignment = Alignment.Start
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                CircularProgressIndicator()
+                                Text(
+                                    "Loading cat images...",
+                                    modifier = Modifier.padding(top = 8.dp)
+                                )
+                            }
+                        }
+                    }
+                    uiState.error != null -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally
                             ) {
                                 Text(
-                                    text = "Cat Information",
-                                    style = MaterialTheme.typography.headlineMedium
+                                    "Error: ${uiState.error}",
+                                    color = MaterialTheme.colorScheme.error
                                 )
-                                Spacer(modifier = Modifier.height(8.dp))
-                                Text("Name: ${catInfo.name}")
-                                Text("Age: ${catInfo.age} years")
-                                Text("Breed: ${catInfo.breed}")
-                                Text("Description: ${catInfo.description}")
+                                Button(
+                                    onClick = { viewModel.refresh() },
+                                    modifier = Modifier.padding(top = 8.dp)
+                                ) {
+                                    Text("Retry")
+                                }
+                            }
+                        }
+                    }
+                    else -> {
+                        LazyVerticalGrid(
+                            columns = GridCells.Fixed(2),
+                            contentPadding = PaddingValues(8.dp),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            items(uiState.catImages) { catImage ->
+                                Card(
+                                    modifier = Modifier.aspectRatio(1f),
+                                    elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+                                ) {
+                                    AsyncImage(
+                                        model = catImage.url,
+                                        contentDescription = "Cat image",
+                                        contentScale = ContentScale.Crop,
+                                        modifier = Modifier.fillMaxSize()
+                                    )
+                                }
                             }
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/org/godslew/gkcatinfosampleapp/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/godslew/gkcatinfosampleapp/di/AppModule.kt
@@ -14,7 +14,7 @@ val appModule = module {
     singleOf(::Greeting)
     single { CatRepository(get()) }
     factoryOf(::GetCatInfoUseCase)
-    factoryOf(::CatViewModel)
+    factory { CatViewModel(get(), get()) }
 }
 
 expect fun getPlatform(): Platform

--- a/composeApp/src/commonMain/kotlin/org/godslew/gkcatinfosampleapp/theme/Theme.kt
+++ b/composeApp/src/commonMain/kotlin/org/godslew/gkcatinfosampleapp/theme/Theme.kt
@@ -1,0 +1,62 @@
+package org.godslew.gkcatinfosampleapp.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+private val DarkColorScheme = darkColorScheme(
+    primary = Color(0xFF6BB6FF),
+    onPrimary = Color(0xFF003258),
+    primaryContainer = Color(0xFF00497D),
+    onPrimaryContainer = Color(0xFFD3E4FF),
+    secondary = Color(0xFFBCC7DB),
+    onSecondary = Color(0xFF263141),
+    secondaryContainer = Color(0xFF3C4758),
+    onSecondaryContainer = Color(0xFFD8E3F7),
+    surface = Color(0xFF1A1C1E),
+    onSurface = Color(0xFFE2E2E6),
+    background = Color(0xFF1A1C1E),
+    onBackground = Color(0xFFE2E2E6),
+    error = Color(0xFFFFB4AB),
+    onError = Color(0xFF690005),
+    errorContainer = Color(0xFF93000A),
+    onErrorContainer = Color(0xFFFFDAD6)
+)
+
+private val LightColorScheme = lightColorScheme(
+    primary = Color(0xFF0061A4),
+    onPrimary = Color(0xFFFFFFFF),
+    primaryContainer = Color(0xFFD3E4FF),
+    onPrimaryContainer = Color(0xFF001C38),
+    secondary = Color(0xFF535F70),
+    onSecondary = Color(0xFFFFFFFF),
+    secondaryContainer = Color(0xFFD8E3F7),
+    onSecondaryContainer = Color(0xFF101C2B),
+    surface = Color(0xFFFBFCFF),
+    onSurface = Color(0xFF1A1C1E),
+    background = Color(0xFFFBFCFF),
+    onBackground = Color(0xFF1A1C1E),
+    error = Color(0xFFBA1A1A),
+    onError = Color(0xFFFFFFFF),
+    errorContainer = Color(0xFFFFDAD6),
+    onErrorContainer = Color(0xFF410002)
+)
+
+@Composable
+fun AppTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) {
+    val colorScheme = when {
+        darkTheme -> DarkColorScheme
+        else -> LightColorScheme
+    }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        content = content
+    )
+}

--- a/composeApp/src/iosMain/kotlin/org/godslew/gkcatinfosampleapp/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/org/godslew/gkcatinfosampleapp/MainViewController.kt
@@ -2,6 +2,7 @@ package org.godslew.gkcatinfosampleapp
 
 import androidx.compose.ui.window.ComposeUIViewController
 import org.godslew.gkcatinfosampleapp.di.appModule
+import org.godslew.gkcatinfosampleapp.di.iosImageLoaderModule
 import org.godslew.gkcatinfosampleapp.di.networkModule
 import org.koin.core.context.startKoin
 
@@ -12,6 +13,6 @@ fun MainViewController() = ComposeUIViewController {
 
 private fun initKoin() {
     startKoin {
-        modules(appModule, networkModule)
+        modules(appModule, networkModule, iosImageLoaderModule)
     }
 }

--- a/composeApp/src/iosMain/kotlin/org/godslew/gkcatinfosampleapp/di/ImageLoaderModule.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/godslew/gkcatinfosampleapp/di/ImageLoaderModule.ios.kt
@@ -3,7 +3,6 @@ package org.godslew.gkcatinfosampleapp.di
 import coil3.ImageLoader
 import coil3.PlatformContext
 import coil3.disk.DiskCache
-import coil3.disk.directory
 import coil3.memory.MemoryCache
 import coil3.network.ktor3.KtorNetworkFetcherFactory
 import coil3.request.crossfade

--- a/composeApp/src/iosMain/kotlin/org/godslew/gkcatinfosampleapp/di/ImageLoaderModule.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/godslew/gkcatinfosampleapp/di/ImageLoaderModule.ios.kt
@@ -1,0 +1,47 @@
+package org.godslew.gkcatinfosampleapp.di
+
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.disk.DiskCache
+import coil3.disk.directory
+import coil3.memory.MemoryCache
+import coil3.network.ktor3.KtorNetworkFetcherFactory
+import coil3.request.crossfade
+import coil3.util.DebugLogger
+import io.ktor.client.HttpClient
+import okio.Path.Companion.toPath
+import platform.Foundation.NSCachesDirectory
+import platform.Foundation.NSSearchPathForDirectoriesInDomains
+import platform.Foundation.NSUserDomainMask
+import org.koin.dsl.module
+
+val iosImageLoaderModule = module {
+    single {
+        ImageLoader.Builder(PlatformContext.INSTANCE)
+            .components {
+                add(KtorNetworkFetcherFactory(get<HttpClient>()))
+            }
+            .memoryCache {
+                MemoryCache.Builder()
+                    .maxSizePercent(PlatformContext.INSTANCE, 0.25)
+                    .build()
+            }
+            .diskCache {
+                val cacheDir = NSSearchPathForDirectoriesInDomains(
+                    NSCachesDirectory,
+                    NSUserDomainMask,
+                    true
+                ).firstOrNull() as? String
+                
+                cacheDir?.let {
+                    DiskCache.Builder()
+                        .directory("$it/image_cache".toPath())
+                        .maxSizeBytes(512L * 1024 * 1024) // 512MB
+                        .build()
+                }
+            }
+            .logger(DebugLogger())
+            .crossfade(true)
+            .build()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ kotlin = "2.2.0"
 koin = "4.1.0"
 ktor = "3.0.2"
 kotlinx-serialization = "1.7.3"
+coil = "3.0.4"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -40,6 +41,9 @@ ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negoti
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
+coil-network-ktor = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
+compose-material-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version.ref = "composeMultiplatform" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- Implemented Material Design 3 dark mode support that follows system theme
- Added Coil image loading library to display cat images in a gallery
- Improved UI with Material Icons and better visual feedback

## Changes
### Dark Mode Implementation
- Created `Theme.kt` with Material Design 3 color schemes for light and dark modes
- Wrapped app content with `AppTheme` composable that detects system theme
- Removed all hardcoded colors from UI components

### Cat Image Gallery
- Integrated Coil3 image loading library with platform-specific modules
- Updated UI to display cat images in a 2-column grid layout
- Modified ViewModel to fetch 4 cat images at a time from the API
- Added AsyncImage component for efficient image loading

### UI Improvements
- Added Material Icons Extended dependency for better icons
- Implemented animated refresh button with rotation animation
- Improved loading and error states with better visual feedback
- All UI elements now properly adapt to theme changes

## Test plan
- [ ] Verify app launches without crashes on Android
- [ ] Verify app launches without crashes on iOS
- [ ] Toggle system dark mode and verify UI colors change appropriately
- [ ] Test refresh functionality - icon should rotate during loading
- [ ] Verify cat images load and display in 2-column grid
- [ ] Test error handling by disabling network and tapping refresh
- [ ] Verify all text remains visible in both light and dark modes

🤖 Generated with [Claude Code](https://claude.ai/code)